### PR TITLE
updates stale github references to tagged releases of blacklight

### DIFF
--- a/v5.14.0/00-first_change.md
+++ b/v5.14.0/00-first_change.md
@@ -15,7 +15,7 @@ One of the first things that that you will want to customize in your Blacklight 
 
 In order to customize the home page text for our new site we will use `override` Blacklight's rails partial for the home page text.  This is one of the most basic methods of customization.
 
-We can find the content of the home page text in the Blacklight codebase at `app/views/catalog/_home_text.html.erb` ([GitHub](https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_home_text.html.erb)). If we create a file with the same name under the same directory structure in our application then we have `overriden` that file and the one from our application will be served up instead.  **We cannot stress enough that you only want to override the smallest piece possible. DO NOT copy all of the Blacklight views into your application or you're going to have a bad time.**
+We can find the content of the home page text in the Blacklight codebase at `app/views/catalog/_home_text.html.erb` ([GitHub](https://github.com/projectblacklight/blacklight/blob/v5.14.0/app/views/catalog/_home_text.html.erb)). If we create a file with the same name under the same directory structure in our application then we have `overriden` that file and the one from our application will be served up instead.  **We cannot stress enough that you only want to override the smallest piece possible. DO NOT copy all of the Blacklight views into your application or you're going to have a bad time.**
 
 If we add the following content to our newly created file and refresh the browser we can see that our file is served up as the home page text instead of the file that shipped with Blacklight.
 

--- a/v5.14.0/02-i18n.md
+++ b/v5.14.0/02-i18n.md
@@ -6,7 +6,7 @@ redirect_from: /i18n/
 blacklight_version: v5.14.0
 ---
 
-Much of the text provided in the UI elements in Blacklight are customizable using rails' [internationalization](http://guides.rubyonrails.org/i18n.html) (i18n).  Blacklight has [translations](https://github.com/projectblacklight/blacklight/tree/master/config/locales) for its UI in 5 languages besides english.  If you happen to find a piece of text that is provided by the Blacklight UI and **not** customizable via i18n please feel free to submit a pull request to fix it or file an issue in the [issue tracker](github.com/projectblacklight/blacklight/issues/new).
+Much of the text provided in the UI elements in Blacklight are customizable using rails' [internationalization](http://guides.rubyonrails.org/i18n.html) (i18n).  Blacklight has [translations](https://github.com/projectblacklight/blacklight/tree/v5.14.0/config/locales) for its UI in 5 languages besides english.  If you happen to find a piece of text that is provided by the Blacklight UI and **not** customizable via i18n please feel free to submit a pull request to fix it or file an issue in the [issue tracker](github.com/projectblacklight/blacklight/issues/new).
 
 In order to override the values provided by Blacklight you need to add keys in your application's locale YAML files (typically located in `config/locales`) for the languages that you would like to change.  For this example, you'll simply update the `blacklight.en.yml` file that was auto-generated into your application for you.  If you're developing a multi-lingual application you'll also want to update the same key in Blacklight's locale files for other languages.
 

--- a/v5.14.0/06-facets.md
+++ b/v5.14.0/06-facets.md
@@ -47,7 +47,7 @@ In this case there is a theoretical lookup table that holds a hash of possible t
 
 ## Partial
 
-One of the more powerful mechanisms for customizing facets is to configure a custom partial to handle rendering the facet.  This will allow the application to provide its own view to replace Blacklight's [facet_limit partial](https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_facet_limit.html.erb).
+One of the more powerful mechanisms for customizing facets is to configure a custom partial to handle rendering the facet.  This will allow the application to provide its own view to replace Blacklight's [facet_limit partial](https://github.com/projectblacklight/blacklight/blob/v5.14.0/app/views/catalog/_facet_limit.html.erb).
 
 {% highlight ruby %}
 # app/controllers/catalog_controller.rb

--- a/v5.14.0/08-overrides.md
+++ b/v5.14.0/08-overrides.md
@@ -8,7 +8,7 @@ blacklight_version: v5.14.0
 
 Much of Blacklight is written in a way that is overridable, helper methods are no different.
 
-Let's take a look at the [module that renders search constraints on results pages](https://github.com/projectblacklight/blacklight/blob/master/app/helpers/blacklight/render_constraints_helper_behavior.rb). This module is mixed into the `Blacklight::RenderConstraintsHelper` which allows us to override methods mixed in.
+Let's take a look at the [module that renders search constraints on results pages](https://github.com/projectblacklight/blacklight/blob/v5.14.0/app/helpers/blacklight/render_constraints_helper_behavior.rb). This module is mixed into the `Blacklight::RenderConstraintsHelper` which allows us to override methods mixed in.
 
 For example, the `render_constraints` method renders the constraints area in the results page.
 

--- a/v7.11.1/00-first_change.md
+++ b/v7.11.1/00-first_change.md
@@ -14,7 +14,7 @@ One of the first things that that you will want to customize in your Blacklight 
 
 In order to customize the home page text for our new site we will use `override` Blacklight's rails partial for the home page text.  This is one of the most basic methods of customization.
 
-We can find the content of the home page text in the Blacklight codebase at `app/views/catalog/_home_text.html.erb` ([GitHub](https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_home_text.html.erb)). If we create a file with the same name under the same directory structure in our application then we have `overriden` that file and the one from our application will be served up instead.  **We cannot stress enough that you only want to override the smallest piece possible. DO NOT copy all of the Blacklight views into your application or you're going to have a bad time.**
+We can find the content of the home page text in the Blacklight codebase at `app/views/catalog/_home_text.html.erb` ([GitHub](https://github.com/projectblacklight/blacklight/blob/v7.11.1/app/views/catalog/_home_text.html.erb)). If we create a file with the same name under the same directory structure in our application then we have `overriden` that file and the one from our application will be served up instead.  **We cannot stress enough that you only want to override the smallest piece possible. DO NOT copy all of the Blacklight views into your application or you're going to have a bad time.**
 
 If we add the following content to our newly created file and refresh the browser we can see that our file is served up as the home page text instead of the file that shipped with Blacklight.
 

--- a/v7.11.1/04-i18n.md
+++ b/v7.11.1/04-i18n.md
@@ -5,7 +5,7 @@ permalink: /v7.11.1/i18n/
 blacklight_version: v7.11.1
 ---
 
-Much of the text provided in the UI elements in Blacklight are customizable using Rails' [internationalization](http://guides.rubyonrails.org/i18n.html) (i18n).  Blacklight has [translations](https://github.com/projectblacklight/blacklight/tree/master/config/locales) for its UI in 10 languages besides english.  If you happen to find a piece of text that is provided by the Blacklight UI and **not** customizable via i18n please feel free to submit a pull request to fix it or file an issue in the [issue tracker](github.com/projectblacklight/blacklight/issues/new).
+Much of the text provided in the UI elements in Blacklight are customizable using Rails' [internationalization](http://guides.rubyonrails.org/i18n.html) (i18n).  Blacklight has [translations](https://github.com/projectblacklight/blacklight/tree/v7.11.1/config/locales) for its UI in 10 languages besides english.  If you happen to find a piece of text that is provided by the Blacklight UI and **not** customizable via i18n please feel free to submit a pull request to fix it or file an issue in the [issue tracker](github.com/projectblacklight/blacklight/issues/new).
 
 In order to override the values provided by Blacklight you need to add keys in your application's locale YAML files (typically located in `config/locales`) for the languages that you would like to change.  For this example, you'll simply update the `blacklight.en.yml` file that was auto-generated into your application for you.  If you're developing a multi-lingual application you'll also want to update the same key in Blacklight's locale files for other languages.
 

--- a/v7.11.1/18-helper-method-overrides.md
+++ b/v7.11.1/18-helper-method-overrides.md
@@ -8,7 +8,7 @@ blacklight_version: v7.11.1
 
 Much of Blacklight is written in a way that is overridable, helper methods are no different.
 
-Let's take a look at the [module that is used to help with some of the layout for Blacklight](https://github.com/projectblacklight/blacklight/blob/master/app/helpers/blacklight/layout_helper_behavior.rb). This  module is mixed into the `Blacklight::BlacklightHelperBehavior` which allows us to override methods mixed in.
+Let's take a look at the [module that is used to help with some of the layout for Blacklight](https://github.com/projectblacklight/blacklight/blob/v7.11.1/app/helpers/blacklight/layout_helper_behavior.rb). This  module is mixed into the `Blacklight::BlacklightHelperBehavior` which allows us to override methods mixed in.
 
 For example, the `html_tag_attributes` method is used to inject HTML tag attributes into the main Blacklight layout.
 

--- a/v7.11.1/22-extending-catalog-controller.md
+++ b/v7.11.1/22-extending-catalog-controller.md
@@ -21,7 +21,7 @@ class StaticPagesController < CatalogController
 +  alias_method :search_action_url, :search_catalog_url
 ```
 
-Next, we need to update the controller to make a solr query and store the result (again, by convention) in the instance variable `@response`. We can copy the way Blacklight does this for the [`CatalogController#index` action](https://github.com/projectblacklight/blacklight/blob/master/app/controllers/concerns/blacklight/catalog.rb#L27) [^2]:
+Next, we need to update the controller to make a solr query and store the result (again, by convention) in the instance variable `@response`. We can copy the way Blacklight does this for the [`CatalogController#index` action](https://github.com/projectblacklight/blacklight/blob/v7.11.1/app/controllers/concerns/blacklight/catalog.rb#L27) [^2]:
 
 ```diff
 class StaticPagesController < CatalogController

--- a/v7.11.1/23-svg-icons.md
+++ b/v7.11.1/23-svg-icons.md
@@ -5,7 +5,7 @@ permalink: /v7.11.1/svg-icons/
 blacklight_version: v7.11.1
 ---
 
-Internally Blacklight uses a helper method, `blacklight_icon`, to render icons throughout the application. This approach relies on an icon being available as an asset in an SVG file. The files are located in Blacklight at [`app/assets/images/blacklight`](https://github.com/projectblacklight/blacklight/tree/master/app/assets/images/blacklight).
+Internally Blacklight uses a helper method, `blacklight_icon`, to render icons throughout the application. This approach relies on an icon being available as an asset in an SVG file. The files are located in Blacklight at [`app/assets/images/blacklight`](https://github.com/projectblacklight/blacklight/tree/v7.11.1/app/assets/images/blacklight).
 
 You can use this functionality in your  Blacklight application in several ways.
 
@@ -17,8 +17,8 @@ Let's say you want to change the search icon used away from a magnifying glass. 
 
 New icons can be added in the same way. For instance if we want to add a "soccer" icon. We could use this one: https://fonts.gstatic.com/s/i/materialiconssharp/sports_soccer/v5/24px.svg?download=true. We then add that to our project at `app/assets/images/blacklight/sports_soccer-24px.svg`.
 
-Next we will be able to use the icon in a partial or helper by calling `blacklight_icon('sports_soccer-24px.svg')`. 
+Next we will be able to use the icon in a partial or helper by calling `blacklight_icon('sports_soccer-24px.svg')`.
 
 ### A note on accessibility
 
-We have taken great care to provide the best possible accessibility experience for icons in Blacklight. You can update the title and aria-label attributes used by updating these in the locale i18n files under the `blacklight.icon` key. You can see [an example of this in GeoBlacklight](https://github.com/geoblacklight/geoblacklight/blob/main/config/locales/geoblacklight.en.yml#L110-L148).
+We have taken great care to provide the best possible accessibility experience for icons in Blacklight. You can update the title and aria-label attributes used by updating these in the locale i18n files under the `blacklight.icon` key. You can see [an example of this in GeoBlacklight](https://github.com/geoblacklight/geoblacklight/blob/v3.1.0/config/locales/geoblacklight.en.yml#L110-L148).


### PR DESCRIPTION
As part of auditing the master to main updates across the blacklight Github org, I found some stale references to code that I changed to match the version of Blacklight the workshop covered.

The default branch on this repo doesn't need to change.