### PR TITLE
Tutorial fixes for 8.0.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Jekyll based site for tutorials on customizing Blacklight applications.
 
+Publishes to: <https://workshop.projectblacklight.org/>
+
 ## Authors
 
 **Jessie Keck**

--- a/_includes/previous_next.html
+++ b/_includes/previous_next.html
@@ -19,6 +19,9 @@
           <span class="pagination-item newer">Next</span>
         {% endif %}
       </div>
+      <div>
+        For a list of pages in the tutorial, click the menu icon on the upper left.
+      </div>
     {% else %}
       {% assign page_index = page_index | plus: 1 %}
     {% endif %}

--- a/v8.0.0.alpha/04-helper-method-overrides.md
+++ b/v8.0.0.alpha/04-helper-method-overrides.md
@@ -6,7 +6,7 @@ redirect_from: /overrides/
 blacklight_version: v8.0.0.alpha
 ---
 
-Much of Blacklight is written in a way that is overridable, helper methods are no different.
+Much of Blacklight is written in a way that is overridable. Helper methods are no different.
 
 Let's take a look at the [module that is used to help with some of the layout for Blacklight](https://github.com/projectblacklight/blacklight/blob/master/app/helpers/blacklight/layout_helper_behavior.rb). This  module is mixed into the `Blacklight::BlacklightHelperBehavior` which allows us to override methods mixed in.
 
@@ -41,7 +41,7 @@ module CustomLayoutHelper
 end
 {% endhighlight %}
 
-Now we are free to override methods to meet our custom application needs. For example, lets override the `html_tag_attributes` method.
+Now we are free to override methods to meet our custom application needs. For example, let's override the `html_tag_attributes` method.
 
 {% highlight ruby %}
 # app/helpers/custom_layout_helper.rb
@@ -66,5 +66,5 @@ This overridden method adds an additional attribute `dir="rtl"` to display our p
 This is just one way that the Blacklight code can be overridden and customized. Similar patterns can be used to customize controllers and search behavior.
 
 <div class="alert alert-primary">
-  For more information about overriding helpers, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuring-and-Customizing-Blacklight#custom-view-helpers">checkout the Blacklight Wiki</a>.
+  For more information about overriding helpers, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuring-and-Customizing-Blacklight#custom-view-helpers">check out the Blacklight Wiki</a>.
 </div>

--- a/v8.0.0.alpha/09-general-configuration-patterns.md
+++ b/v8.0.0.alpha/09-general-configuration-patterns.md
@@ -14,6 +14,7 @@ The keys provided to many fields are intended to point either to a field in solr
 The following example will configure a facet with the field name `language_ssim` based on the key that was passed in.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'language_ssim'
 end
@@ -24,6 +25,7 @@ end
 It's typical, but not required, that the Blacklight field key matches the solr field name.  This is the case in the example above.  However, you can also configure a field to use a different solr field name, which is useful if you want to use the same field with different display characteristics, or if you want to keep Solr internals out of your URLs:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'language', field: 'language_facet_ssim'
 end
@@ -33,6 +35,7 @@ end
 There are a few ways to add labels to fields (as you'll notice if you're following along the example above got a default label), but one of the ways is to add a label key direction. Many of the configurations Blacklight provides take a label option.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'language_ssim', label: 'Language'
 end
@@ -44,6 +47,7 @@ You can control the display of elements by passing values to `if` and `unless`. 
 
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'language_ssim', label: 'Language', if: false
 end
@@ -56,6 +60,7 @@ You can also control display using the `if`/`unless` configurations by passing a
 In the example below, the language facet will only be displayed when a format of "Book" has been selected in the facets.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'language_ssim', label: 'Language', if: -> (controller, _config, _field) do
     selected_formats = controller.params.dig('f', 'format') || []
@@ -66,5 +71,5 @@ end
 ```
 
 <div class="alert alert-primary">
-  For more information about configuring Blacklight, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuring-and-Customizing-Blacklight#configuration">checkout the Blacklight Wiki</a>.
+  For more information about configuring Blacklight, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuring-and-Customizing-Blacklight#configuration">check out the Blacklight Wiki</a>.
 </div>

--- a/v8.0.0.alpha/10-metadata-fields.md
+++ b/v8.0.0.alpha/10-metadata-fields.md
@@ -22,7 +22,7 @@ The configuration patterns outlined on [General Configuration Patterns](/v8.0.0.
 
 ## Labeling via Internationalization (i18n)
 
-All the text in Blacklight's UI are configured via rails' i18n files. While you can apply a string label directly in the Blackklight config, you can also label these in your i18n config files (e.g. in `config/locales/blacklight.en.yml`).
+All the text in Blacklight's UI are configured via rails' i18n files. While you can apply a string label directly in the Blacklight config, you can also label these in your i18n config files (e.g. in `config/locales/blacklight.en.yml`).
 
 If you wanted to change the label of all `author_tsim` fields to "Creator" you can do that by adding the label to your locale file.
 

--- a/v8.0.0.alpha/10-metadata-fields.md
+++ b/v8.0.0.alpha/10-metadata-fields.md
@@ -8,6 +8,7 @@ blacklight_version: v8.0.0.alpha
 The metadata fields that are displayed in the index (search results) and show (record view) can be configured using the `add_index_field` and `add_show_field` configuration methods in the Blacklight config.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   # Index / Search Results
   config.add_index_field 'author_tsim', label: 'Author'
@@ -55,6 +56,7 @@ There are a few configuration options that can help you format the data using Bl
 One common customization is to update the way that Blacklight joins multiple values by default. Blacklight's rendering pipeline uses rails' [`to_sentence`](https://apidock.com/rails/Array/to_sentence) helper (with its default options) to join multiple solr field values together, and allows you to pass in alternate options using the `separator_options` configuration option.  For instance, if we wanted to separate all values by line breaks instead of the `,`s and `and` we can do that with the following configuration (the record with ID 92117465 is a good example of this in action).
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   # This field configuration would need to be added as it is not in the generated controller
   config.add_show_field 'author_addl_tsim', label: 'Additional authors', separator_options: {
@@ -68,6 +70,7 @@ end
 It's also possible to link these values using the built-in `link_to_facet` configuration option. Two of the show fields that it might make sense to do this with (and are indexed appropriately for faceting) are the format and language fields on the show view.
 
 ```diff
+# app/controllers/catalog_controller.rb
 - config.add_show_field 'format', label: 'Format'
 - config.add_show_field 'language_ssim', label: 'Language'
 + config.add_show_field 'format', label: 'Format', link_to_facet: true
@@ -85,6 +88,7 @@ The field values can also be mapped using field configuration. There are two eas
 Accessors are handy when the transformation you want to make is based entirely on the data from the field (or document). One thing you might do is map names given as "last name, first name" into "first name last name" [^1]. The most basic accessor configuration is using the explicit accessor configuration:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   # Index / Search Results
   config.add_index_field 'author_tsim', label: 'Author', accessor: :author_name
@@ -120,6 +124,7 @@ end
 Alternatively, you can use the `values` parameter to provide document values [^2]. This is a good choice if the value varies based on the request (e.g. the values are internationalized using the user's profile, or an administrator sees additional data, etc):
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   # Index / Search Results
   config.add_index_field 'JSON', label: 'Solr Document', values: ->(field_config, document, _) {
@@ -133,6 +138,7 @@ end
 The field values can also be rendered using a custom viewcomponent. This is a good choice if you want to render a field value in a more complex way than the default rendering pipeline. With a custom view component, you can render the field value in any way you want.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 config.add_show_field 'JSON', label: 'Solr Document', component: DetailsComponent
 ```
 

--- a/v8.0.0.alpha/11-facet-fields.md
+++ b/v8.0.0.alpha/11-facet-fields.md
@@ -182,7 +182,7 @@ class SimpleFilterClass < Blacklight::SearchState::FilterField
     new_state.reset(params)
   end
 
-  # Facet values set int he URL
+  # Facet values set in the URL
   def values(except: [])
     Array(search_state.params[key])
   end
@@ -200,7 +200,7 @@ end
 
 
 <div class="alert alert-primary">
-  For more information about configuring facets in Blacklight, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuration---Facet-Fields">checkout the Blacklight Wiki</a>.
+  For more information about configuring facets in Blacklight, <a href="https://github.com/projectblacklight/blacklight/wiki/Configuration---Facet-Fields">check out the Blacklight Wiki</a>.
 </div>
 
 [^1]: This is sorted by Solr based on the indexed term; Solr offers no control over direction, lexical vs natural sort order, etc.

--- a/v8.0.0.alpha/11-facet-fields.md
+++ b/v8.0.0.alpha/11-facet-fields.md
@@ -112,21 +112,30 @@ For this example, we want to customize the display of the facet, so we'll need t
 
 ```erb
 <%= render(@layout.new(facet_field: @facet_field)) do |component| %>
-  <% component.with(:label) do %>
+  <% component.with_label do %>
     <%= @facet_field.label %>
   <% end %>
-  <% component.with(:body) do %>
+  <% component.with_body do %>
+    <%= helpers.render(Blacklight::FacetFieldInclusiveConstraintComponent.new(facet_field: @facet_field)) %>
     <ul class="facet-values list-unstyled">
-      <%= render_facet_limit_list @facet_field.paginator, @facet_field.key %>
+      <%= render facet_items %>
     </ul>
+    <%# backwards compatibility, ugh %>
+    <% if @layout == Blacklight::FacetFieldNoLayoutComponent && !@facet_field.in_modal? && @facet_field.modal_path %>
+      <div class="more_facets">
+        <%= link_to t("more_#{@facet_field.key}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: @facet_field.label),
+          @facet_field.modal_path,
+          data: { blacklight_modal: 'trigger' } %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>
 ```
 
-and then make a nice visible change:
+and then make a nice visible change (the label disappears):
 
 ```diff
-<% component.with(:label) do %>
+  <% component.with_label do %>
 -   <%= @facet_field.label %>
 +   -> <%= @facet_field.label %> <-
 <% end %>

--- a/v8.0.0.alpha/11-facet-fields.md
+++ b/v8.0.0.alpha/11-facet-fields.md
@@ -10,6 +10,7 @@ Blacklight provides facets to help a user filter search results.
 Facet fields can be configured using the `add_facet_field` configuration method:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_facet_field 'format', label: 'Format'
 end
@@ -20,6 +21,7 @@ Solr calculates the number of hits for each format value. Blacklight displays th
 If there are many facet values, you can use `limit` to control how many appear on the search results page.
 
 ```diff
+# app/controllers/catalog_controller.rb
 - config.add_facet_field 'subject_ssim', label: 'Topic'
 + config.add_facet_field 'subject_ssim', label: 'Topic', limit: 5
 ```
@@ -28,12 +30,14 @@ Additional facet values are available in a modal popup.
 
 You can control whether the facet is displayed expanded by default:
 ```diff
+# app/controllers/catalog_controller.rb
 - config.add_facet_field 'format', label: 'Format'
 + config.add_facet_field 'format', label: 'Format', collapse: false
 ```
 
 You can also sort the values alphabetically [^1]:
 ```diff
+# app/controllers/catalog_controller.rb
 - config.add_facet_field 'format', label: 'Format', collapse: false
 + config.add_facet_field 'format', label: 'Format', collapse: false, sort: 'alpha', limit: -1
 ```
@@ -41,6 +45,7 @@ You can also sort the values alphabetically [^1]:
 If the facet data is mutually exclusive, you might consider using `single` to allow the user to toggle between values easily:
 
 ```diff
+# app/controllers/catalog_controller.rb
 - config.add_facet_field 'pub_date_ssim', label: 'Publication Year'
 + config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
 ```
@@ -51,6 +56,7 @@ If the facet data is mutually exclusive, you might consider using `single` to al
 Blacklight also has built-in support for other types of Solr faceting. Query facets are good for providing facets based on dynamic data not directly present in the index. You can specify the "values" of a query facet and the applicable Solr query using the `query` parameter:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
    years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5 } TO *]" },
    years_10: { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10 } TO *]" },
@@ -137,6 +143,7 @@ Blacklight uses the `Blacklight::SearchState` to map a user's query parameters t
 Here, we'll map the language field to a single-valued `language` parameter instead of the default `f[format][]`:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 config.add_facet_field 'language_ssim', filter_class: SimpleFilterClass
 ```
 

--- a/v8.0.0.alpha/12-search-fields.md
+++ b/v8.0.0.alpha/12-search-fields.md
@@ -5,7 +5,7 @@ permalink: /v8.0.0.alpha/search_fields/
 blacklight_version: v8.0.0.alpha
 ---
 
-Blacklight provides a UI element to choose a which "search fields" to execute the search against when multiple search field options are configured.  This is often used to provide a `Title`, `Author`, etc. search in addition to the default `All fields`.  You can think of these as different request handlers (`qt` parameter) in solr, however; it's not uncommon to use a single request handler and configure the solr_parameters directly in the search field configuration.
+Blacklight provides a UI element to choose which "search fields" to execute the search against when multiple search field options are configured.  This is often used to provide a `Title`, `Author`, etc. search in addition to the default `All fields`.  You can think of these as different request handlers (`qt` parameter) in solr, however; it's not uncommon to use a single request handler and configure the solr_parameters directly in the search field configuration.
 
 <div class="image-well">
   <img src="/public/images/blacklight-7-search-fields.png" alt="Blacklight search fields dropdown" />

--- a/v8.0.0.alpha/12-search-fields.md
+++ b/v8.0.0.alpha/12-search-fields.md
@@ -15,6 +15,7 @@ Blacklight provides a UI element to choose a which "search fields" to execute th
 If there aren't any search fields configured (or one default one like below) the `qt` parameter set in the Blacklight config's `default_solr_parameters` will be used and there will be no search field dropdown presented to the user.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_search_field 'all_fields', label: 'All Fields'
 end
@@ -23,6 +24,7 @@ end
 Adding an new search field to the dropdown can be accomplished by using the `add_search_field` configuration option.  By default, the key passed to `add_search_field` will be passed to solr as the `qt` parameter.  In the example below, this would use the `title` request handler by passing `qt=title` when querying solr (when the user chooses "Title" for the search field dropdown).
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_search_field 'all_fields', label: 'All Fields'
   config.add_search_field 'title', label: 'Title'
@@ -32,6 +34,7 @@ end
 It's possible to use a different request handler than the key passed to `add_search_field`.  This way the `search_field` parameter in the application URL will remain `title` while the solr request handler that maps to remains know to the application configuration only (allowing you to change the request handler without breaking existing urls/bookmarks).
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_search_field 'all_fields', label: 'All Fields'
   config.add_search_field 'title', label: 'Title' do |field|
@@ -43,6 +46,7 @@ end
 A common pattern is to configure `solr_parameters` directly in the `add_search_field` configuration (and use the default search results handler).  You will likely want to pass `qf` and `pf` values that are defined in your default request handler.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_search_field 'all_fields', label: 'All Fields'
   config.add_search_field 'title', label: 'Title' do |field|

--- a/v8.0.0.alpha/13-sort-fields.md
+++ b/v8.0.0.alpha/13-sort-fields.md
@@ -15,6 +15,7 @@ Blacklight provides a UI element to choose a sort order for results when multipl
 Sort options can be configured using the `add_sort_field` configuration method.  The following configuration won't display because there is only one sort option to choose from.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_sort_field 'score desc', label: 'relevance'
 end
@@ -23,6 +24,7 @@ end
 Even though this will not display a sort option, it still controls the default sort behavior of search results.  It's often useful to supply sub sorts, even for a default score based relevancy search result as facet based results will all have the same score.  We can update the default sort of our results by updating the sort field configuration and adding pub date and title sub-sorts.  With the configuration below a facet only search (or simply an empty query) will be returned sorted.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
 end
@@ -31,6 +33,7 @@ end
 Adding additional sort fields is relatively straight forward. As above with the relevancy sort, it is most likely a good idea to provide sub sorts so when documents have the same relevancy score they are sorted using other criteria.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
   config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
@@ -40,6 +43,7 @@ end
 The first value passed to `add_sort_field` will be both the sort value sent to solr as well as the parameter sent through the application url. It's possible to obscure the solr fields and their sort direction from the url by passing a key as the first parameter and passing the sort configuration explicitly as the `sort` key.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 configure_blacklight do |config|
   config.add_sort_field 'relevance', sort: 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
   config.add_sort_field 'year', sort: 'pub_date_si desc, title_si asc', label: 'year'

--- a/v8.0.0.alpha/14-solr-parameters.md
+++ b/v8.0.0.alpha/14-solr-parameters.md
@@ -42,6 +42,7 @@ In development, it can be handy to see the stored fields for a document. While y
 Note that this API is disabled by default, both to discourage coupling applications to the underlying Solr document format and to avoid leaking non-public information present in the document.
 
 ```ruby
+# app/controllers/catalog_controller.rb
 ## Should the raw solr document endpoint (e.g. /catalog/:id/raw) be enabled
 config.raw_endpoint.enabled = true
 ```
@@ -51,6 +52,7 @@ config.raw_endpoint.enabled = true
 We can add or change the default parameters sent to Solr in the `CatalogController`. In `./app/controllers/catalog_controller.rb`, we can see the default configuration sets the number of items per search result:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
 config.default_solr_params = {
   rows: 10
@@ -62,6 +64,7 @@ Try changing the value to 20.
 We can also override behavior from the requestHandler. Try adding a `qf` parameter and tweaking the fields + weights:
 
 ```ruby
+# app/controllers/catalog_controller.rb
 ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
 config.default_solr_params = {
   rows: 20,

--- a/v8.0.0.alpha/15-thumbnails.md
+++ b/v8.0.0.alpha/15-thumbnails.md
@@ -49,6 +49,7 @@ end
 Sometimes, not all documents have a thumbnail. In this case, you can configure a default thumbnail to be used for documents that don't have a thumbnail.
 
 {% highlight ruby %}
+# app/controllers/catalog_controller.rb
   config.index.default_thumbnail = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMDAiIGhlaWdodD0iMTUwIiB2aWV3Qm94PSIwIDAgMzAwIDE1MCI-IDxyZWN0IGZpbGw9IiNkZGQiIHdpZHRoPSIzMDAiIGhlaWdodD0iMTUwIi8-IDx0ZXh0IGZpbGw9InJnYmEoMCwwLDAsMC41KSIgZm9udC1mYW1pbHk9Ikdlb3JnaWEsIHNlcmlmIiBmb250LXNpemU9IjMwIiBkeT0iMTAuNSIgZm9udC13ZWlnaHQ9Im5vcm1hbCIgeD0iNTAlIiB5PSI1MCUiIHRleHQtYW5jaG9yPSJtaWRkbGUiPjMwMMOXMTUwPC90ZXh0PiA8L3N2Zz4='
 {% endhighlight%}
 

--- a/v8.0.0.alpha/18-extending-catalog-controller.md
+++ b/v8.0.0.alpha/18-extending-catalog-controller.md
@@ -14,14 +14,16 @@ First, we need to pull in the Blacklight configuration from the `CatalogControll
 + class StaticPagesController < CatalogController
 ```
 
-If we try to look at the home page now, we'll see a routing error (`ActionController::UrlGenerationError in StaticPages#home`). We'll also need to tell the `StaticPagesController` we want to use the catalog routes from `CatalogController` [^1]. By convention, Blacklight uses the `search_action_url` method to route to the correct place. We can override that in the controller:
+If we try to look at the home page now, we'll see a routing error (`ActionController::UrlGenerationError in StaticPages#home`). We'll also need to tell the `StaticPagesController` we want to use the catalog routes from `CatalogController`. By convention, Blacklight uses the `search_action_url` method to route to the correct place. Update routes.rb to give static_pages access to those routes.
 
 ```diff
-class StaticPagesController < CatalogController
-+  alias_method :search_action_url, :search_catalog_url
+# routes.rb
++  resource :static_pages, only: [:home], as: 'home', path: '/', controller: 'static_pages' do
++    concerns :searchable
++  end
 ```
 
-Next, we need to update the controller to make a solr query and store the result (again, by convention) in the instance variable `@response`. We can copy the way Blacklight does this for the [`CatalogController#index` action](https://github.com/projectblacklight/blacklight/blob/master/app/controllers/concerns/blacklight/catalog.rb#L27) [^2]:
+Next, we need to update the controller to make a solr query and store the result (again, by convention) in the instance variable `@response`. We can copy the way Blacklight does this for the [`CatalogController#index` action](https://github.com/projectblacklight/blacklight/blob/master/app/controllers/concerns/blacklight/catalog.rb#L27) [^1]:
 
 ```diff
 class StaticPagesController < CatalogController
@@ -56,6 +58,4 @@ class StaticPagesController < CatalogController
 
 <hr />
 
-[^1]: We might want the opposite if we wanted our controller to be a specialization of `CatalogController` (perhaps providing a filtered "ebooks" view or an administration view with a specialized display and tooling). If we wanted to do that, we'd add search routing to the controller in `./config/routes.rb`.
-
-[^2]: This index method does a little more than we need to do to add a few facets. Note, too, the `deprecated_document_list` argument coming back from the search service; in Blacklight 8, this method will return only the response.
+[^1]: This index method does a little more than we need to do to add a few facets. Note, too, the `deprecated_document_list` argument coming back from the search service; in Blacklight 8, this method will return only the response.

--- a/v8.0.0.alpha/20-other-plugins.md
+++ b/v8.0.0.alpha/20-other-plugins.md
@@ -22,5 +22,5 @@ These types of plugins provide a specific type of Blacklight application experie
 Blacklight plugins exist as separate software projects, and can even have adjacent communities that help maintain them.
 
 <div class="alert alert-primary">
-  For more information about Blacklight plugins, <a href="https://github.com/projectblacklight/blacklight/wiki/Blacklight-Add-ons">checkout the Blacklight Wiki</a>.
+  For more information about Blacklight plugins, <a href="https://github.com/projectblacklight/blacklight/wiki/Blacklight-Add-ons">check out the Blacklight Wiki</a>.
 </div>

--- a/v8.0.0.alpha/21-apis.md
+++ b/v8.0.0.alpha/21-apis.md
@@ -69,6 +69,7 @@ Note that this can be used in combination with any search query, facets, or sort
 To add a different API format, you can instruct Blacklight to provide alternative results. In `app/controllers/catalog_controller.rb`, add:
 
 ```diff
+# app/controllers/catalog_controller.rb
  configure_blacklight do |config|
 +   config.index.respond_to.csv = true
  end

--- a/v8.0.0.alpha/21-apis.md
+++ b/v8.0.0.alpha/21-apis.md
@@ -56,7 +56,6 @@ http://127.0.0.1:3000/catalog/00282214.marcjson
 
 ### Search results
 
-In addition to
 You can also affect which search results response formats are available, in addition to the out-of-the-box HTML, JSON, Atom and RSS feeds. Take a look at, e.g.:
 
 - [http://127.0.0.1:3000/catalog?search_field=all_fields&q=&format=marc](http://127.0.0.1:3000/catalog?search_field=all_fields&q=&format=marc)


### PR DESCRIPTION
Make some improvements to the 8.0.0-alpha tutorial after running through it. Each of these items is in a separate commit for ease of reviewing, and also I can revert individual commits if you don't want some of the changes.
- Add catalog_controller.rb comment to ruby snippets to show where to make changes.
- In the facet-fields page, update suggested code for super_special_facet_component.html.erb since the underlying code has changed and the suggested code resulted in an error
- Fix typos in tutorial text
- In the extending-catalog-controller page, update the instructions to fix the static_page_controller routes. The given instructions resulted in an error
- Give a hint about how to show the list of tutorial pages under the Prev/Next buttons. It didn't occur to me to click the menu icon on the upper left, because I had used it to select between versions of the tutorial
- Add the published URL (https://workshop.projectblacklight.org/) to the README so that the repo is more findable